### PR TITLE
Compiling mustache templates at compile time

### DIFF
--- a/mustache.cabal
+++ b/mustache.cabal
@@ -45,6 +45,8 @@ library
                      , OverloadedStrings
                      , LambdaCase
                      , TupleSections
+                     , TemplateHaskell
+                     , QuasiQuotes
   build-depends:       base >=4.7 && <5
                      , text
                      , parsec
@@ -59,6 +61,8 @@ library
                      , scientific
                      , base-unicode-symbols
                      , containers
+                     , template-haskell
+                     , th-lift
   hs-source-dirs:      src
   default-language:    Haskell2010
   ghc-options:

--- a/src/Text/Mustache/Compile.hs
+++ b/src/Text/Mustache/Compile.hs
@@ -8,9 +8,11 @@ Stability   : experimental
 Portability : POSIX
 -}
 {-# LANGUAGE UnicodeSyntax #-}
+{-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE QuasiQuotes #-}
 module Text.Mustache.Compile
   ( automaticCompile, localAutomaticCompile, TemplateCache, compileTemplateWithCache
-  , compileTemplate, cacheFromList, getPartials, getFile
+  , compileTemplate, cacheFromList, getPartials, getFile, mustache
   ) where
 
 
@@ -25,6 +27,9 @@ import           Data.HashMap.Strict        as HM
 import           Data.Monoid.Unicode        ((∅))
 import           Data.Text                  hiding (concat, find, map, uncons)
 import qualified Data.Text.IO               as TIO
+import           Language.Haskell.TH        (Q, Exp, Loc, location, loc_filename, loc_start)
+import qualified Language.Haskell.TH.Syntax as THS
+import           Language.Haskell.TH.Quote  (QuasiQuoter(QuasiQuoter), quoteExp)
 import           Prelude.Unicode
 import           System.Directory
 import           System.FilePath
@@ -33,7 +38,6 @@ import           Text.Mustache.Types
 import           Text.Parsec.Error
 import           Text.Parsec.Pos
 import           Text.Printf
-
 
 {-|
   Compiles a mustache template provided by name including the mentioned partials.
@@ -141,6 +145,30 @@ getFile (templateDir : xs) fp =
       (lift $ TIO.readFile filePath)
   where
     filePath = templateDir </> fp
+
+
+-- |
+-- Compile a mustache 'Template' at compile time. Usage:
+--
+-- > {-# LANGUAGE QuasiQuotes #-}
+-- > import Text.Mustache.Compile (mustache)
+-- >
+-- > foo :: Template
+-- > foo = [mustache|This is my inline {{ template }} created at compile time|]
+--
+-- Partials are not supported in compile time templates.
+
+mustache ∷ QuasiQuoter
+mustache = QuasiQuoter {quoteExp = \unprocessedTemplate -> do
+  l <- location
+  compileTemplateTH (fileAndLine l) unprocessedTemplate }
+
+fileAndLine ∷ Loc -> String
+fileAndLine loc = loc_filename loc ++ ":" ++ (show ∘ fst ∘ loc_start $ loc)
+
+compileTemplateTH ∷ String -> String -> Q Exp
+compileTemplateTH filename unprocessed =
+  either (fail ∘ ("Parse error in mustache template: " ++) ∘ show) THS.lift $ compileTemplate filename (pack unprocessed)
 
 
 -- ERRORS

--- a/src/Text/Mustache/Compile.hs
+++ b/src/Text/Mustache/Compile.hs
@@ -7,6 +7,7 @@ Maintainer  : dev@justus.science
 Stability   : experimental
 Portability : POSIX
 -}
+{-# OPTIONS_GHC -fno-warn-missing-fields #-}
 {-# LANGUAGE UnicodeSyntax #-}
 {-# LANGUAGE TemplateHaskell #-}
 {-# LANGUAGE QuasiQuotes #-}
@@ -159,14 +160,14 @@ getFile (templateDir : xs) fp =
 -- Partials are not supported in compile time templates.
 
 mustache ∷ QuasiQuoter
-mustache = QuasiQuoter {quoteExp = \unprocessedTemplate -> do
-  l <- location
+mustache = QuasiQuoter {quoteExp = \unprocessedTemplate → do
+  l ← location
   compileTemplateTH (fileAndLine l) unprocessedTemplate }
 
-fileAndLine ∷ Loc -> String
+fileAndLine ∷ Loc → String
 fileAndLine loc = loc_filename loc ++ ":" ++ (show ∘ fst ∘ loc_start $ loc)
 
-compileTemplateTH ∷ String -> String -> Q Exp
+compileTemplateTH ∷ String → String → Q Exp
 compileTemplateTH filename unprocessed =
   either (fail ∘ ("Parse error in mustache template: " ++) ∘ show) THS.lift $ compileTemplate filename (pack unprocessed)
 

--- a/src/Text/Mustache/Compile.hs
+++ b/src/Text/Mustache/Compile.hs
@@ -13,7 +13,7 @@ Portability : POSIX
 {-# LANGUAGE QuasiQuotes #-}
 module Text.Mustache.Compile
   ( automaticCompile, localAutomaticCompile, TemplateCache, compileTemplateWithCache
-  , compileTemplate, cacheFromList, getPartials, getFile, mustache
+  , compileTemplate, cacheFromList, getPartials, getFile, mustache, embedTemplate
   ) where
 
 
@@ -171,6 +171,21 @@ compileTemplateTH ∷ String → String → Q Exp
 compileTemplateTH filename unprocessed =
   either (fail ∘ ("Parse error in mustache template: " ++) ∘ show) THS.lift $ compileTemplate filename (pack unprocessed)
 
+-- |
+-- Compile a mustache 'Template' at compile time. Usage:
+--
+-- > {-# LANGUAGE TemplateHaskell #-}
+-- > import Text.Mustache.Compile (embedTemplate)
+-- >
+-- > foo :: Template
+-- > foo = $(embedTemplate "dir/file.mustache")
+--
+-- Partials are not supported in compile time templates.
+
+embedTemplate :: FilePath → Q Exp
+embedTemplate filePath = do
+  stringFile ← THS.runIO $ readFile filePath
+  compileTemplateTH filePath stringFile
 
 -- ERRORS
 

--- a/src/Text/Mustache/Parser.hs
+++ b/src/Text/Mustache/Parser.hs
@@ -39,7 +39,6 @@ module Text.Mustache.Parser
 import           Control.Monad
 import           Control.Monad.Unicode
 import           Data.Char              (isAlphaNum, isSpace)
-import           Data.Functor           ((<$>))
 import           Data.List              (nub)
 import           Data.Monoid.Unicode    ((∅), (⊕))
 import           Data.Text              as T (Text, null, pack)

--- a/src/Text/Mustache/Render.hs
+++ b/src/Text/Mustache/Render.hs
@@ -20,12 +20,12 @@ module Text.Mustache.Render
   ) where
 
 
-import           Control.Applicative    ((<$>), (<|>))
+import           Control.Applicative    ((<|>))
 import           Control.Arrow          (first)
 import           Control.Monad
 import           Control.Monad.Unicode
 import           Data.Foldable          (fold)
-import           Data.HashMap.Strict    as HM hiding (map)
+import           Data.HashMap.Strict    as HM hiding (map, keys)
 import           Data.Maybe             (fromMaybe)
 import           Data.Monoid.Unicode
 import           Data.Scientific        (floatingOrInteger)

--- a/src/Text/Mustache/Types.hs
+++ b/src/Text/Mustache/Types.hs
@@ -12,7 +12,8 @@ Portability : POSIX
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE TupleSections         #-}
 {-# LANGUAGE UnicodeSyntax         #-}
-{-# LANGUAGE BangPatterns #-}
+{-# LANGUAGE BangPatterns          #-}
+{-# LANGUAGE TemplateHaskell       #-}
 module Text.Mustache.Types
   (
   -- * Types for the Parser / Template
@@ -34,21 +35,22 @@ module Text.Mustache.Types
   ) where
 
 
-import qualified Data.Aeson          as Aeson
-import           Data.HashMap.Strict as HM
-import qualified Data.HashSet        as HS
-import qualified Data.Map            as Map
+import qualified Data.Aeson               as Aeson
+import           Data.HashMap.Strict      as HM
+import qualified Data.HashSet             as HS
+import qualified Data.Map                 as Map
 import           Data.Scientific
 import           Data.Text
-import qualified Data.Text.Lazy      as LT
-import qualified Data.Vector         as V
+import qualified Data.Text.Lazy           as LT
+import qualified Data.Vector              as V
+import           Language.Haskell.TH.Lift (Lift(lift), deriveLift)
 import           Prelude.Unicode
 
 -- | Syntax tree for a mustache template
 type STree = ASTree Text
 
 
-type ASTree α = [Node α] 
+type ASTree α = [Node α]
 
 
 -- | Basic values composing the STree
@@ -116,7 +118,7 @@ instance ToMustache Integer where
   toMustache = Number ∘ fromInteger
 
 instance ToMustache Int where
-  toMustache = toMustache . toInteger
+  toMustache = toMustache ∘ toInteger
 
 instance ToMustache Char where
   toMustache = toMustache ∘ (:[])
@@ -379,3 +381,13 @@ data Template = Template
   , ast      ∷ STree
   , partials ∷ TemplateCache
   } deriving (Show)
+
+instance Lift TemplateCache where
+  lift = const [|HM.empty|]
+
+instance Lift Text where
+  lift = lift ∘ unpack
+
+deriveLift ''DataIdentifier
+deriveLift ''Node
+deriveLift ''Template

--- a/src/Text/Mustache/Types.hs
+++ b/src/Text/Mustache/Types.hs
@@ -7,6 +7,7 @@ Maintainer  : dev@justus.science
 Stability   : experimental
 Portability : POSIX
 -}
+{-# OPTIONS_GHC -fno-warn-orphans  #-}
 {-# LANGUAGE FlexibleContexts      #-}
 {-# LANGUAGE FlexibleInstances     #-}
 {-# LANGUAGE MultiParamTypeClasses #-}

--- a/test/unit/Spec.hs
+++ b/test/unit/Spec.hs
@@ -1,9 +1,10 @@
-{-# LANGUAGE LambdaCase        #-}
-{-# LANGUAGE NamedFieldPuns    #-}
-{-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE UnicodeSyntax     #-}
-{-# LANGUAGE TemplateHaskell   #-}
-{-# LANGUAGE QuasiQuotes       #-}
+{-# OPTIONS_GHC -fno-warn-orphans #-}
+{-# LANGUAGE LambdaCase           #-}
+{-# LANGUAGE NamedFieldPuns       #-}
+{-# LANGUAGE OverloadedStrings    #-}
+{-# LANGUAGE UnicodeSyntax        #-}
+{-# LANGUAGE TemplateHaskell      #-}
+{-# LANGUAGE QuasiQuotes          #-}
 module Main where
 
 

--- a/test/unit/Spec.hs
+++ b/test/unit/Spec.hs
@@ -200,15 +200,21 @@ converterSpec =
 instance Eq Template where
   (==) = (==) `on` ast
 
-quasiQuotedSpec :: Spec
-quasiQuotedSpec =
-  describe "mustacheTemplateQuasiQuoter" $
-    it "creates templates at compile time" $
-      Right [mustache|This {{ template }} was injected at compile time|] `shouldBe` compileTemplate "Template Name" "This {{ template }} was injected at compile time"
+compileTimeSpec :: Spec
+compileTimeSpec =
+  describe "compileTimeCompiling" $ do
+
+    it "creates compiled templates from a QuasiQuoter" $
+      Right [mustache|This {{ template }} was injected at compile time with a quasiquoter|] `shouldBe`
+        compileTemplate "Template Name" "This {{ template }} was injected at compile time with a quasiquoter"
+
+    it "creates compiled templates from an embedded file" $
+      Right $(embedTemplate "test/unit/examples/test-template.txt.mustache") `shouldBe`
+        compileTemplate "Template Name" "This {{ template }} was injected at compile time with an embedded file\n"
 
 main :: IO ()
 main = hspec $ do
   parserSpec
   substituteSpec
   converterSpec
-  quasiQuotedSpec
+  compileTimeSpec

--- a/test/unit/examples/test-template.txt.mustache
+++ b/test/unit/examples/test-template.txt.mustache
@@ -1,0 +1,1 @@
+This {{ template }} was injected at compile time with an embedded file


### PR DESCRIPTION
To make mustache templates, the user has two options: 
- `localAutomaticCompile ∷ FilePath → IO (Either ParseError Template)`
- `compileTemplate ∷ String → Text → Either ParseError Template` 

However, if the whole template is available at compile time, we can make versions of both of these methods that have a return type of `Template` using Template Haskell. 

This PR introduces compiling templates from external files. Example: 
```haskell
{-# LANGUAGE TemplateHaskell #-}
import Text.Mustache.Compile (embedTemplate)

foo :: Template
foo = $(embedTemplate "dir/file.mustache")
```

Or alternatively compiling text inline of the file with 
```haskell
{-# LANGUAGE QuasiQuotes #-}
import Text.Mustache.Compile (mustache)

foo :: Template
foo = [mustache|This is my inline {{ template }} created at compile time|]
```

I did my best to match the style but all the same I would welcome any feedback to make this submission suitable for the project. 