### PR TITLE
Add support for Partials to compile-time templates

### DIFF
--- a/test/unit/Spec.hs
+++ b/test/unit/Spec.hs
@@ -12,6 +12,7 @@ import           Data.Either
 import           Data.Function         (on)
 import           Data.Monoid
 import qualified Data.Text             as T
+import           System.IO.Unsafe      (unsafePerformIO)
 import           Test.Hspec
 import           Text.Mustache
 import           Text.Mustache.Compile
@@ -208,8 +209,16 @@ compileTimeSpec =
         compileTemplate "Template Name" "This {{ template }} was injected at compile time with a quasiquoter"
 
     it "creates compiled templates from an embedded file" $
-      Right $(embedTemplate "test/unit/examples/test-template.txt.mustache") `shouldBe`
+      Right $(embedTemplate ["test/unit/examples"] "test-template.txt.mustache") `shouldBe`
         compileTemplate "Template Name" "This {{ template }} was injected at compile time with an embedded file\n"
+
+    it "creates compiled templates from a single embedded file" $
+      Right $(embedSingleTemplate "test/unit/examples/test-template.txt.mustache") `shouldBe`
+        compileTemplate "Template Name" "This {{ template }} was injected at compile time with an embedded file\n"
+
+    it "creates compiled templates from an embedded file containing partials" $
+      Right $(embedTemplate ["test/unit/examples", "test/unit/examples/partials"] "test-template-partials.txt.mustache") `shouldBe`
+        unsafePerformIO (automaticCompile ["test/unit/examples", "test/unit/examples/partials"] "test-template-partials.txt.mustache")
 
 main :: IO ()
 main = hspec $ do

--- a/test/unit/examples/partials/test-partial.txt.mustache
+++ b/test/unit/examples/partials/test-partial.txt.mustache
@@ -1,0 +1,1 @@
+and {{ partials }}

--- a/test/unit/examples/test-template-partials.txt.mustache
+++ b/test/unit/examples/test-template-partials.txt.mustache
@@ -1,0 +1,1 @@
+This {{ template }} was injected at compile time with an embedded file {{> test-partial.txt.mustache }}


### PR DESCRIPTION
Addresses requests in #17

- Change `embedTemplate` to accept a search space parameter, and change the underlying implementation to utilize `automaticCompile` under the hood. This provides the appropriate error message for missing templates.
- Add `embedSingleTemplate` that is a rename of the old implementation of `embedTemplate` to keep the simple form factor for those with simpler mustache use cases. Open to renaming suggestions for `embedSingleTemplate` function