### PR TITLE
Escape apostrophes

### DIFF
--- a/src/Text/Mustache/Internal.hs
+++ b/src/Text/Mustache/Internal.hs
@@ -34,6 +34,7 @@ escapeXML = concatMap $ \x -> IntMap.findWithDefault [x] (ord x) mp
 xmlEntities :: [(String, String)]
 xmlEntities =
   [ ("quot", "\"")
+  , ("#39", "'")
   , ("amp" , "&")
   , ("lt"  , "<")
   , ("gt"  , ">")

--- a/test/unit/Spec.hs
+++ b/test/unit/Spec.hs
@@ -116,14 +116,14 @@ substituteSpec =
     it "substitutes a html escaped value for a variable" $
       substitute
         (toTemplate [Variable escaped (NamedData ["name"])])
-        (object ["name" ~> ("<tag>" :: T.Text)])
-      `shouldBe` "&lt;tag&gt;"
+        (object ["name" ~> ("\" ' < > &" :: T.Text)])
+      `shouldBe` "&quot; &#39; &lt; &gt; &amp;"
 
     it "substitutes raw value for an unescaped variable" $
       substitute
         (toTemplate [Variable unescaped (NamedData ["name"])])
-        (object ["name" ~> ("<tag>" :: T.Text)])
-      `shouldBe` "<tag>"
+        (object ["name" ~> ("\" ' < > &" :: T.Text)])
+      `shouldBe` "\" ' < > &"
 
     it "substitutes a section when the key is present (and an empty object)" $
       substitute


### PR DESCRIPTION
There are only 5 XML entities to escape: http://stackoverflow.com/questions/1091945/what-characters-do-i-need-to-escape-in-xml-documents/1091953#1091953

This package escapes 4 of them but it doesn't escape apostrophes (`'`). This PR escapes apostrophes.

I went with `&#39;` as the escape sequence. The alternatives are `&apos;` or `&#x27;`. The former is not valid HTML 4 (see https://github.com/ruby/ruby/pull/154/commits/538bd3ccfc969da49309e567999b34ed69cdce66) and the latter is apparently not as widely supported (see https://github.com/ruby/ruby/commit/bbb6b5e84e53b17c5c08072cae05aed6de6e3abe#commitcomment-1800099). 