### PR TITLE
Treat Null values as Falsy in sections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Mustache library changelog
 
+## v2.1.4
+
+- Treat Null as falsy in sections
+
 ## v2.1.3
 
 - Added excaping for the apostrophe "'" as per xml spec, courtesy to @tfausak

--- a/mustache.cabal
+++ b/mustache.cabal
@@ -1,5 +1,5 @@
 name:                mustache
-version:             2.1.3
+version:             2.1.4
 synopsis:            A mustache template parser library.
 description:
   Allows parsing and rendering template files with mustache markup. See the
@@ -33,7 +33,7 @@ source-repository this
   type:     git
   branch:   master
   location: git://github.com/JustusAdam/mustache.git
-  tag:      v2.1.3
+  tag:      v2.1.4
 
 
 

--- a/src/Text/Mustache/Render.hs
+++ b/src/Text/Mustache/Render.hs
@@ -150,6 +150,7 @@ substituteASTWithValAndCache cAst cPartials ctx =
               in
                 mapM_ (substitute' newContext) secSTree
         Just (Bool False) -> return ()
+        Just Null -> return ()
         Just (Lambda l)   -> mapM_ (substitute' context) (l context secSTree)
         Just focus'       ->
           let

--- a/test/unit/Spec.hs
+++ b/test/unit/Spec.hs
@@ -173,6 +173,12 @@ substituteSpec =
         (object ["section" ~> False])
       `shouldBe` ""
 
+    it "does not substitute a section when the key is present (and null)" $
+      substitute
+        (toTemplate [Section (NamedData ["section"]) [TextBlock "t"]])
+        (object ["section" ~> Null])
+      `shouldBe` ""
+
     it "does not substitute a section when the key is present (and empty list)" $
       substitute
         (toTemplate [Section (NamedData ["section"]) [TextBlock "t"]])


### PR DESCRIPTION
I'm building a Static Site generator using your mustache lib (which has been excellent and useful so far; so thanks!!) and I'm pulling in yaml data into Aeson objects; and am sometimes converting them into other data objects using fromJSON:

```haskell
data Post = Post
  { title :: String
  , content :: String
  , author :: Maybe String
  }
```

In my template I have a section like this:

```html
<div>
  {{#author}}
    Written by: {{.}}
  {{/author}}
</div>
```

Which of course I expect to show up and print the author when it's `Just author` and I want it to print nothing when the author is not defined; Since ToMustache goes through Aeson to build the object, the result is an Object like:

```json
{
  "author" : null
}
```

Currently mustache is treating the Null value as truthy and ends up printing:
```html
<div>
    Written by: null
</div>
```

This patch treats null as falsy giving the expected behaviour.

Note that if the key were missing entirely (instead of having a null value) the behaviour works as expected already.

Cheers! Let me know if I'm missing anything 😉 