### PR TITLE
Prevents rendering lambda'd sections twice

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Mustache library changelog
 
+## v2.2.3
+
+- Quick fix to prevent catchSubstitute from reporting substitutions to the renderer.
+
 ## v2.2.2
 
 - Added a function to catch a substitution result

--- a/mustache.cabal
+++ b/mustache.cabal
@@ -1,5 +1,5 @@
 name:                mustache
-version:             2.2.2
+version:             2.2.3
 synopsis:            A mustache template parser library.
 description:
   Allows parsing and rendering template files with mustache markup. See the

--- a/src/Text/Mustache/Render.hs
+++ b/src/Text/Mustache/Render.hs
@@ -103,7 +103,9 @@ checkedSubstituteValue template dataStruct =
 
 -- | Catch the results of running the inner substitution.
 catchSubstitute :: SubM a -> SubM (a, Text)
-catchSubstitute = fmap (second (T.concat . snd)) . SubM . listen . runSubM'
+catchSubstitute = fmap (second (T.concat . snd)) . SubM . hideResults . listen . runSubM'
+  where
+    hideResults = censor (\(errs, _) -> (errs, []))
 
 -- | Substitute an entire 'STree' rather than just a single 'Node'
 substituteAST :: STree -> SubM ()

--- a/test/unit/Spec.hs
+++ b/test/unit/Spec.hs
@@ -185,6 +185,22 @@ substituteSpec =
         (object ["section" ~> ([] :: [T.Text])])
       `shouldBe` ""
 
+    it "substitutes a lambda by applying lambda to contained text" $
+      substitute
+        (toTemplate [Section (NamedData ["lambda"]) [TextBlock "t"]])
+        (object ["lambda" ~> (overText T.toUpper)])
+      `shouldBe` "T"
+
+
+    it "substitutes a lambda by applying lambda to the nested substitution results" $
+      substitute
+        (toTemplate [Section (NamedData ["lambda"]) [TextBlock "t", Variable escaped (NamedData ["inner"])]])
+        (object [ "lambda" ~> (overText T.toUpper)
+                , "inner" ~> ("var" :: T.Text)
+                ])
+      `shouldBe` "TVAR"
+
+
     it "substitutes a nested section" $
       substitute
         (toTemplate [Variable escaped (NamedData ["outer", "inner"])])


### PR DESCRIPTION
I tracked down a problem where the current lambda implementation renders everything it's passed twice, once before the lambda is applied and once after:

## Current behaviour

Given the template:

```html
{{#uppercase}}
my text
{{/uppercase}}
```

With the lambda: `Lambda $ overText T.toUpper` it renders to:

```html
my textMY TEXT
```
This (as far as I can tell) is because SubM uses a Writer monad to collect the templates, so the current implementation:

```haskell
  Just (Lambda l)  -> substituteAST =<< l secSTree
```

Runs the lambda, THEN runs substitute over it again, in our case the lambda is something like:

```haskell
lam = Lambda $ \content -> do
  (_, sub) <- M.catchSubstitute $ M.substituteAST content
  return $ T.toUpper sub
```

This is happening because catch substitute renders the content inside SubM and uses the writer
to report its results; then it returns the new AST which gets rendered again, again reporting the results.

I fixed it by preventing catchSubstitute from reporting its substitutions, while still passing through errors. Cheers!
