### PR TITLE
Fixed yaml deprecation warning and bumped stack

### DIFF
--- a/app/Main.hs
+++ b/app/Main.hs
@@ -8,7 +8,7 @@ import qualified Data.ByteString                 as B (readFile)
 import qualified Data.ByteString.Lazy            as BS (readFile)
 import           Data.Foldable                   (for_)
 import qualified Data.Text.IO                    as TIO (putStrLn)
-import           Data.Yaml                       (decodeEither)
+import           Data.Yaml                       (decodeEither')
 
 import           System.Console.CmdArgs.Implicit (Data, Typeable, argPos, args,
                                                   cmdArgs, def, help, summary,
@@ -44,7 +44,11 @@ readJSON = fmap eitherDecode . BS.readFile
 
 
 readYAML :: FilePath -> IO (Either String Value)
-readYAML = fmap decodeEither . B.readFile
+readYAML filepath = do
+  result <- fmap decodeEither' $ B.readFile filepath
+  case result of
+    Left err  -> pure $ Left (show err)
+    Right val -> pure $ Right val
 
 
 main :: IO ()

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -4,6 +4,7 @@ module Main (main) where
 
 
 import           Data.Aeson                      (Value, eitherDecode)
+import           Data.Bifunctor                  (first)
 import qualified Data.ByteString                 as B (readFile)
 import qualified Data.ByteString.Lazy            as BS (readFile)
 import           Data.Foldable                   (for_)
@@ -44,11 +45,7 @@ readJSON = fmap eitherDecode . BS.readFile
 
 
 readYAML :: FilePath -> IO (Either String Value)
-readYAML filepath = do
-  result <- fmap decodeEither' $ B.readFile filepath
-  case result of
-    Left err  -> pure $ Left (show err)
-    Right val -> pure $ Right val
+readYAML = fmap (first show . decodeEither') . B.readFile
 
 
 main :: IO ()

--- a/package.yaml
+++ b/package.yaml
@@ -1,5 +1,5 @@
 name: mustache
-version: '2.3.1'
+version: '2.3.2'
 synopsis: A mustache template parser library.
 description: ! 'Allows parsing and rendering template files with mustache markup.
   See the

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,7 +1,7 @@
 # For more information, see: https://github.com/commercialhaskell/stack/blob/release/doc/yaml_configuration.md
 
 # Specifies the GHC version and set of packages available (e.g., lts-3.5, nightly-2015-09-21, ghc-7.10.2)
-resolver: lts-14.22
+resolver: lts-14.25
 
 # Local packages, usually specified by relative directory name
 packages:

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,7 +1,7 @@
 # For more information, see: https://github.com/commercialhaskell/stack/blob/release/doc/yaml_configuration.md
 
 # Specifies the GHC version and set of packages available (e.g., lts-3.5, nightly-2015-09-21, ghc-7.10.2)
-resolver: lts-14.17
+resolver: lts-14.22
 
 # Local packages, usually specified by relative directory name
 packages:


### PR DESCRIPTION
```
mustache              > [1 of 1] Compiling Main
mustache              >
mustache              > app\Main.hs:47:17: warning: [-Wdeprecations]
mustache              >     In the use of `decodeEither' (imported from Data.Yaml):
mustache              >     Deprecated: "Please use decodeEither' or decodeThrow, which provide more useful failures"
mustache              >    |
mustache              > 47 | readYAML = fmap decodeEither . B.readFile
mustache              >    |                 ^^^^^^^^^^^^
mustache              > Linking .stack-work\dist\5c8418a7\build\haskell-mustache\haskell-mustache.exe ...
```