### PR TITLE
Drop unused `either` dependency

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -53,7 +53,6 @@ library:
   dependencies:
   - parsec
   - mtl >=2.2.1
-  - either
   - unordered-containers
   - vector
   - directory


### PR DESCRIPTION
[Release deprecation notion](https://github.com/JustusAdam/mustache/commit/47bc24e4119c945dee2af50f853d51aece7c6e9b#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4ed)
[The actual code where the package instances where replaced completely](https://github.com/danichts/mustache/commit/9d854b3c27a65b555aaac1d122555bfb27fc0d1c#diff-2422a9175b4bdec0895e4c7e56d6ae6e5196d493752f35a2d9aa436a224fce36)

That lil' thing is especially nasty for compiling sources 