### PR TITLE
GHC 9.0.1 compat

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Mustache library changelog
 
+## v2.3.2
+
+- Added support for GHC 9.0.1
+
 ## v2.3.0
 
 - Changed `EitherT` to `ExceptT` (deprecation)

--- a/src/Text/Mustache/Internal/Types.hs
+++ b/src/Text/Mustache/Internal/Types.hs
@@ -24,7 +24,8 @@ import           Data.Text
 import qualified Data.Text.Lazy           as LT
 import qualified Data.Vector              as V
 import           Data.Word                (Word8, Word16, Word32, Word64)
-import           Language.Haskell.TH.Lift (Lift (lift), deriveLift)
+import           Language.Haskell.TH.Lift (deriveLift)
+import           Language.Haskell.TH.Syntax
 import           Numeric.Natural          (Natural)
 
 
@@ -380,16 +381,21 @@ data Template = Template
   , partials :: TemplateCache
   } deriving (Show)
 
+
+deriveLift ''DataIdentifier
+deriveLift ''Node
+deriveLift ''Template
+
 instance Lift TemplateCache where
+#if MIN_VERSION_template_haskell(2,16,0)
+  liftTyped m = [|| HM.fromList $$(liftTyped $ HM.toList m) ||]
+#else
   lift m = [| HM.fromList $(lift $ HM.toList m) |]
+#endif
 
 --Data.Text 1.2.4.0 introduces its own Lift Text instance
 #if !MIN_VERSION_text(1,2,4)
 instance Lift Text where
   lift = lift . unpack
 #endif
-
-deriveLift ''DataIdentifier
-deriveLift ''Node
-deriveLift ''Template
 


### PR DESCRIPTION
* the order of TH splices is more important in GHC 9
* the minimal complete definition of `Lift` is `liftTyped` since `template-haskell-2.16.0.0`