### PR TITLE
Treat null values as falsey in inverted sections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Mustache library changelog
 
+## v2.4.1
+
+- Also treat Null as falsey in inverted sections
+
 ## v2.4.0
 
 - Support for aeson 2

--- a/package.yaml
+++ b/package.yaml
@@ -1,5 +1,5 @@
 name: mustache
-version: '2.4.0'
+version: '2.4.1'
 synopsis: A mustache template parser library.
 description: ! 'Allows parsing and rendering template files with mustache markup.
   See the

--- a/src/Text/Mustache/Render.hs
+++ b/src/Text/Mustache/Render.hs
@@ -154,6 +154,7 @@ substituteNode (InvertedSection (NamedData secName) invSecSTree) =
   search secName >>= \case
     Just (Bool False) -> contents
     Just (Array a)    | V.null a -> contents
+    Just Null         -> contents
     Nothing           -> contents
     _                 -> return ()
   where

--- a/test/unit/Spec.hs
+++ b/test/unit/Spec.hs
@@ -161,6 +161,12 @@ substituteSpec =
           ])
       `shouldBe` "var1var2"
 
+    it "substitutes an inverse section when the key is present (and null)" $
+      substitute
+        (toTemplate [InvertedSection (NamedData ["section"]) [TextBlock "t"]])
+        (object ["section" ~> Null])
+      `shouldBe` "t"
+
     it "does not substitute a section when the key is not present" $
       substitute
         (toTemplate [Section (NamedData ["section"]) [TextBlock "t"]])


### PR DESCRIPTION
This PR changes the handle of the `null` values.

If some supplied `value` takes a `null` value and we have two cases:

Case 1:
```
{{#value}}
    Something.
{{/value}}
```

Case 2:
```
{{^value}}
    Something.
{{/value}}
```

Both cases currently result in nothing being rendered.

This PR changes this such that, in Case 2, `"Something"` is rendered.  This change ensures conformance with the mustache spec which clarifies that for null values in inverted sections, the text should be rendered (https://github.com/mustache/spec/blob/master/specs/inverted.yml#L49) as discussed in this [issue](https://github.com/JustusAdam/mustache/issues/40#issuecomment-1412920305).

