### PR TITLE
implement the exact opposite of the inverted match

### DIFF
--- a/src/Text/Mustache/Compile.hs
+++ b/src/Text/Mustache/Compile.hs
@@ -118,6 +118,7 @@ getPartials = join . fmap getPartials'
 getPartials' :: Node Text -> [FilePath]
 getPartials' (Partial _ p) = return p
 getPartials' (Section _ n) = getPartials n
+getPartials' (ExistingSection _ n) = getPartials n
 getPartials' (InvertedSection _ n) = getPartials n
 getPartials' _                     = mempty
 

--- a/src/Text/Mustache/Internal/Types.hs
+++ b/src/Text/Mustache/Internal/Types.hs
@@ -28,7 +28,6 @@ import qualified Data.Text.Lazy           as LT
 import qualified Data.Vector              as V
 import           Data.Word                (Word8, Word16, Word32, Word64)
 import           Language.Haskell.TH.Lift (deriveLift)
-import           Language.Haskell.TH.Syntax
 import           Numeric.Natural          (Natural)
 
 
@@ -101,6 +100,7 @@ type ASTree α = [Node α]
 data Node α
   = TextBlock α
   | Section DataIdentifier (ASTree α)
+  | ExistingSection DataIdentifier (ASTree α)
   | InvertedSection DataIdentifier (ASTree α)
   | Variable Bool DataIdentifier
   | Partial (Maybe α) FilePath

--- a/src/Text/Mustache/Render.hs
+++ b/src/Text/Mustache/Render.hs
@@ -148,6 +148,18 @@ substituteNode (Section (NamedData secName) secSTree) =
       shiftContext newContext $ substituteAST secSTree
     Nothing -> tellError $ SectionTargetNotFound secName
 
+-- substituting an existing section (exact invert of the inverted section)
+substituteNode (ExistingSection  Implicit _) = tellError InvertedImplicitSection
+substituteNode (ExistingSection (NamedData secName) invSecSTree) =
+  search secName >>= \case
+    Just (Bool False) -> return ()
+    Just (Array a)    | V.null a -> return ()
+    Just Null         -> return ()
+    Nothing           -> return ()
+    _                 -> contents
+  where
+    contents = mapM_ substituteNode invSecSTree
+
 -- substituting an inverted section
 substituteNode (InvertedSection  Implicit _) = tellError InvertedImplicitSection
 substituteNode (InvertedSection (NamedData secName) invSecSTree) =


### PR DESCRIPTION
This implements `{{?something}}...{{/something}}` syntax, which works as an **exact** opposite of `{{^something}}...{{/something}}`, that is, fires precisely if the `something` does **not** evaluate to a falsey (empty, null) value. This allows implementing simple and exact if/else constructions, which is actually quite hard to achieve properly with original mustache. (I guess that lack of these is one of the ground reasons why e.g. [handlebars.js](https://handlebarsjs.com/) exist.)

This is actually not in mustache spec but given the minor size of the extension and some other tiny improvements already in this repo, I guess it could be viable to get merged. (At the bare minimum I wouldn't need to keep the repo forked... :D)

Thanks for maintaining the library!
