### PR TITLE
Re-export ParseError

### DIFF
--- a/src/Text/Mustache/Parser.hs
+++ b/src/Text/Mustache/Parser.hs
@@ -25,7 +25,7 @@ module Text.Mustache.Parser
 
   -- * Parser
 
-  , Parser, MustacheState
+  , Parser, MustacheState, ParseError
 
   -- * Mustache Constants
 


### PR DESCRIPTION
This way I don't have to explicitly depend on `parsec` if I want to mention the `ParseError` type in my code. It is part of the `mustache` package's public API, after all.