### PR TITLE
Release v0.4.3

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,28 @@
+name: publish
+
+permissions:
+  contents: write
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - run: cabal check --ignore=missing-upper-bounds
+
+      - uses: sol/haskell-autotag@v1
+        id: autotag
+
+      - run: cabal sdist
+
+      - uses: haskell-actions/hackage-publish@v1.1
+        with:
+          hackageToken: ${{ secrets.HACKAGE_AUTH_TOKEN }}
+          publish: true
+        if: steps.autotag.outputs.created

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Mustache library changelog
 
-## v2.4.1
+## v2.4.3
 - Compatibility with GHC 9.12.*
 
 ## v2.4.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Mustache library changelog
 
+## v2.4.1
+- Compatibility with GHC 9.12.*
+
 ## v2.4.2
 
 - Also treat Null as falsey in inverted sections

--- a/mustache.cabal
+++ b/mustache.cabal
@@ -5,7 +5,7 @@ cabal-version: 1.12
 -- see: https://github.com/sol/hpack
 
 name:           mustache
-version:        2.4.2
+version:        2.4.3
 synopsis:       A mustache template parser library.
 description:    Allows parsing and rendering template files with mustache markup. See the
                 mustache <http://mustache.github.io/mustache.5.html language reference>.

--- a/package.yaml
+++ b/package.yaml
@@ -1,5 +1,5 @@
 name: mustache
-version: '2.4.2'
+version: '2.4.3'
 synopsis: A mustache template parser library.
 description: ! 'Allows parsing and rendering template files with mustache markup.
   See the


### PR DESCRIPTION
- [ ] add `HACKAGE_AUTH_TOKEN`
- [ ] rename default branch to `main` (or alternatively adjust `.github/workflows/publish.yml`)
- [ ] squash commits